### PR TITLE
Translate GoT to pl_pl.

### DIFF
--- a/src/main/resources/assets/fabricenchantments/lang/pl_pl.json
+++ b/src/main/resources/assets/fabricenchantments/lang/pl_pl.json
@@ -11,5 +11,6 @@
   "enchantment.fabricenchantments.double_swing": "Podwójny zamach",
   "enchantment.fabricenchantments.sniper": "Sniper",
   "enchantment.fabricenchantments.beheading": "Łowca głów",
-  "enchantment.fabricenchantments.paralysis": "Paraliż"
+  "enchantment.fabricenchantments.paralysis": "Paraliż",
+  "enchantment.fabricenchantments.god_of_thunder": "Gromowładny"
 }


### PR DESCRIPTION
"Gromowładny" means shooting/wielding thunder. It's used in Greek mythology etc but if you prefer literal "God of Thunder" then change it to "Bóg piorunów".